### PR TITLE
Translate PDF data from English to Japanese

### DIFF
--- a/cheat-sheet.typ
+++ b/cheat-sheet.typ
@@ -237,17 +237,17 @@
 
 #let jj-status = freeform-command(
   [jj status],
-  [Shows current and \ parent change, \ and file modifications.],
+  [現在の変更と親の変更、およびファイルの変更を表示します。],
 )
 
 #let jj-plain = freeform-command(
   [jj],
-  [Shows important changes \ in the repo.],
+  [リポジトリの重要な変更を表示します。],
 )
 
 #let jj-log = freeform-command(
   [jj log -r ..],
-  [Shows all changes \ in the repo.],
+  [リポジトリ内のすべての変更を表示します。],
 )
 
 // ~~~~~~~~~
@@ -290,7 +290,7 @@
     change("r", (0, 0), highlighted-bookmark: "feat/ui")
     change("q", (0, 4.8), highlighted-bookmark: "feat/api")
   },
-  [#text-highlight[] Prints all bookmarks.]
+  [#text-highlight[] すべてのブックマークを印刷します。]
 )
 
 // ~~~~~~~~~~~~
@@ -300,7 +300,7 @@
 #let jj-show = read-command(
   [jj show],
   change("r", (0, 0), working: true, highlighted-description: "edit foo"),
-  [#text-highlight[] Prints this change's description.]
+  [#text-highlight[] この変更の説明を印刷します。]
 )
 
 #let jj-describe = write-command(
@@ -385,7 +385,7 @@
     change("q", (1, 0), highlighted-files: 1)
     edge("r", "q")
   },
-  [#text-highlight[] Prints the diff between \ #text-files(1) and #text-files(2).]
+  [#text-highlight[] #text-files(1) と #text-files(2) の間の差分を印刷します。]
 )
 
 #let jj-restore = write-command(
@@ -438,7 +438,7 @@
 
 #let jj-undo = freeform-command(
   [jj undo],
-  [Undoes the last command.#h(-0.35em)],
+  [最後のコマンドを元に戻します。#h(-0.35em)],
 )
 
 // ~~~~~~
@@ -460,19 +460,19 @@
   )
 }
 #let legend = make-legend((
-  (canvas(node("r", (0, 0))), [a _change_]),
-  (working-glyph, [the _working change_ ("working copy revision")]),
-  (text-description("edit foo"), [a change's _description_]),
-  (text-bookmark("feat/ui"), [a _bookmark_]),
-  (text-files(1), [a state of the filesystem]),
-  (text-edit(1), [a change's diff]),
+  (canvas(node("r", (0, 0))), [変更]),
+  (working-glyph, [作業中の変更（作業コピーリビジョン）]),
+  (text-description("edit foo"), [変更の説明]),
+  (text-bookmark("feat/ui"), [ブックマーク]),
+  (text-files(1), [ファイルシステムの状態]),
+  (text-edit(1), [変更の差分]),
 ))
 
 // ~~~~~~~~~~~
 // Cheat Sheet
 // ~~~~~~~~~~~
 
-#align(center)[#text(font: "IBM Plex Sans")[= JJ Cheat Sheet]]
+#align(center)[#text(font: "IBM Plex Sans")[= JJ チートシート]]
 #v(1em)
 
 #let row(..args) = {
@@ -519,4 +519,4 @@
   legend,
 )
 
-#place(bottom + right, text-attribution[justinpombrio.net \ & lark.gay \ Feb 2025])
+#place(bottom + right, text-attribution[justinpombrio.net \ & lark.gay \ 2025年2月])

--- a/reference.typ
+++ b/reference.typ
@@ -17,180 +17,118 @@
 #show emph: it => text(fill: emph-color, weight: "semibold", it)
 
 
-= JJ Reference
+= JJ リファレンス
 
-// This is a _reference_ for the Jujutsu version control system. It exists to help you learn and
-// remember the details of Jujutsu, once you have already grokked the basics.
+// これはJujutsuバージョン管理システムのための_リファレンス_です。基本を理解した後、Jujutsuの詳細を学び、覚えるのに役立ちます。
 
-== Model
+== モデル
 
-A Jujutsu repository is a DAG (directed acyclic graph) whose nodes are called _changes_. Each change
-has:
+Jujutsuリポジトリは、ノードが_変更_と呼ばれるDAG（有向非巡回グラフ）です。各変更には以下が含まれます：
 
-- A state of the filesystem within the repository directory. You can imagine each change storing a
-  full copy of the directory and all the files in it, though `jj` is more efficient than this.
-- File _conflicts_. Some files in a change may contain conflicts, from a variety of different
-  sources. These conflicts are local to the change. (Unlike `git`, they do not block your use of
-  `jj`.)
-- One or more _parent_ changes. Though there is a root change which has no parents and always has
-  an empty directory.
-- A textual _description_ of the change, a.k.a. a commit message. This is always present, but
-  defaults to the empty string.
+- リポジトリディレクトリ内のファイルシステムの状態。各変更がディレクトリとその中のすべてのファイルの完全なコピーを保存していると想像できますが、`jj`はこれよりも効率的です。
+- ファイル_コンフリクト_。変更の一部のファイルには、さまざまなソースからのコンフリクトが含まれている場合があります。これらのコンフリクトは変更にローカルです（`git`とは異なり、`jj`の使用を妨げることはありません）。
+- 1つ以上の_親_変更。ただし、親がいないルート変更があり、常に空のディレクトリを持っています。
+- 変更のテキスト_説明_、すなわちコミットメッセージ。これは常に存在しますが、デフォルトでは空の文字列です。
 
-There is some additional information attached to the DAG:
+DAGには追加の情報が添付されています：
 
-- Exactly one of the changes is the _working change_, written `@`. The docs call this the "working
-  copy revision". (This is analogous to `git`'s `HEAD`.)
-- There may be some _bookmarks_, which are unique string labels on changes. (When interfacing with
-  `git`, these bookmarks act as branch names.)
-- The repository may also be linked to a _remote repository_ (e.g. Github). If so, when `push`ing
-  and `fetch`ing, `jj` records the _last known position_ of each remote bookmark, written
-  `BOOKMARK@REMOTE` (e.g. `feat-ui@origin`).
+- 正確に1つの変更が_作業中の変更_であり、`@`と書かれます。ドキュメントではこれを「作業コピーリビジョン」と呼びます（これは`git`の`HEAD`に相当します）。
+- いくつかの_ブックマーク_があり、変更に一意の文字列ラベルを付けることができます（`git`とインターフェースする場合、これらのブックマークはブランチ名として機能します）。
+- リポジトリは_リモートリポジトリ_（例：Github）にリンクされている場合があります。その場合、`push`および`fetch`時に、`jj`は各リモートブックマークの_最後に知られている位置_を記録します。これは`BOOKMARK@REMOTE`（例：`feat-ui@origin`）と書かれます。
 
-Most `jj` commands modify your local repository DAG in some way. Some general rules will help you
-predict how it responds to modifications:
+ほとんどの`jj`コマンドは、何らかの方法でローカルリポジトリDAGを変更します。いくつかの一般的なルールは、変更に対する応答を予測するのに役立ちます：
 
-- When you make `@` point at a change, your repository directory is updated to match that change's
-  files.
-- If you delete the change that `@` is pointing at, `@` moves to a new empty change off of its
-  parent(s).
-- If a change has no file modifications and no description, and is not referenced by `@` or by a
-  bookmark, it disappears silently into the night.
-- A change represents a diff. Moving a change tries to apply the diff to its new parent. This
-  may cause merge conflicts.
-- Many commands act on `@` by default. Almost all of them can take a `-r/--revision` argument to act
-  on a different change.
-  // (Of the commands in the Cheat Sheet that show `@`, all can be applied to a
-  // different change using `-r` except for `jj bookmark move` and `jj restore`, which take `--from`
-  // and `--to` arguments instead.)
+- `@`を変更にポイントすると、リポジトリディレクトリがその変更のファイルに一致するように更新されます。
+- `@`が指している変更を削除すると、`@`はその親から新しい空の変更に移動します。
+- 変更にファイルの変更や説明がなく、`@`やブックマークによって参照されていない場合、それは静かに消え去ります。
+- 変更は差分を表します。変更を移動すると、その差分を新しい親に適用しようとします。これによりマージコンフリクトが発生する可能性があります。
+- 多くのコマンドはデフォルトで`@`に対して動作します。ほとんどすべてのコマンドは、`-r/--revision`引数を取って別の変更に対して動作することができます。
+  //（Cheat Sheetに表示されている`@`を示すコマンドのうち、`jj bookmark move`と`jj restore`を除いて、すべてのコマンドは`-r`を使用して別の変更に適用できます。これらは代わりに`--from`および`--to`引数を取ります。）
 
-=== File Conflicts
+=== ファイルコンフリクト
 
-If the working change (`@`) has a _file conflict_, resolving it is as simple as editing the file so
-as to no longer have conflict markers (`<<<<<<<`, `=======`, etc.) in it. For a binary file,
-replace the file with the version you want. `jj restore` may be useful for this purpose. (Unlike
-`git`, file conflicts don't block you.)
+作業中の変更（`@`）に_ファイルコンフリクト_がある場合、それを解決するのは、ファイルを編集してコンフリクトマーカー（`<<<<<<<`、`=======`など）がなくなるようにするだけです。バイナリファイルの場合、ファイルを希望するバージョンに置き換えます。この目的のために`jj restore`が役立つかもしれません（`git`とは異なり、ファイルコンフリクトはあなたを妨げません）。
 
 === jj git push
 
-`jj git push` copies changes from the local repo into the remote repo. If a local change has been
-modified since it was last pushed, it becomes a brand new change in the remote repo (just like
-force pushing in `git` replaces old commits with new commits). To prevent you from accidentally
-doing this to `main`, `jj git push` makes all pushed changes in the primary branch immutable. You
-can still edit them if you want, but you have to pass the `--ignore-immutable` flag.
+`jj git push`は、ローカルリポジトリからリモートリポジトリに変更をコピーします。ローカル変更が最後にプッシュされてから変更された場合、それはリモートリポジトリで新しい変更になります（`git`での強制プッシュが古いコミットを新しいコミットに置き換えるのと同じように）。`main`に対してこれを誤って行わないようにするために、`jj git push`はプライマリブランチのすべてのプッシュされた変更を不変にします。まだ編集することはできますが、`--ignore-immutable`フラグを渡す必要があります。
 
-All local bookmarks are similarly copied to the remote repo. If a bookmark is present
-both locally and remotely, `jj` checks if its (locally recorded) _last seen position_ matches its
-current position in the remote repo. If so, the bookmark's position in the remote repo is updated.
-If not, this command fails and tells you to `jj git fetch` first (because it means that someone else
-updated the bookmark since you last pushed it).
+すべてのローカルブックマークも同様にリモートリポジトリにコピーされます。ブックマークがローカルとリモートの両方に存在する場合、`jj`はその（ローカルに記録された）_最後に見た位置_がリモートリポジトリでの現在の位置と一致するかどうかを確認します。一致する場合、リモートリポジトリでのブックマークの位置が更新されます。一致しない場合、このコマンドは失敗し、最初に`jj git fetch`を実行するように指示します（これは、他の誰かが最後にプッシュしてからブックマークを更新したことを意味します）。
 
 === jj git fetch
 
-`jj git fetch` copies changes from the remote repo into the local repo. If a change has been
-modified in the remote repo, it turns into a new change locally. Though most of the time you're just
-fetching fresh new changes.
+`jj git fetch`は、リモートリポジトリからローカルリポジトリに変更をコピーします。リモートリポジトリで変更が行われた場合、それはローカルで新しい変更に変わります。ただし、ほとんどの場合、新しい変更をフェッチするだけです。
 
-Local bookmarks are advanced to match the change that they're on in the remote repo. However, if the
-change a bookmark is on in the remote is not a descendant of the change it's on locally,
-`jj git fetch` creates a second copy of that bookmark.
-This is called a _bookmark conflict_ because it violates the invariant that bookmark names
-are unique. (This is analogous to `git pull` producing a merge conflict.) It is
-up to you how to resolve this "bookmark conflict". Some of the options available to you:
+ローカルブックマークは、リモートリポジトリでの変更に一致するように進められます。ただし、リモートでの変更がローカルでの変更の子孫でない場合、`jj git fetch`はそのブックマークの2番目のコピーを作成します。これは_ブックマークコンフリクト_と呼ばれます。これは、ブックマーク名が一意であるという不変条件を破るためです（これは`git pull`がマージコンフリクトを生成するのと同様です）。この「ブックマークコンフリクト」を解決する方法はあなた次第です。利用可能なオプションのいくつか：
 
-- If you want to merge the two changes, say `jj new CHANGE-ID-1 CHANGE-ID-2`, resolve any file
-  conflicts, then update the bookmark with `jj bookmark move BOOKMARK-NAME`.
-  (You can get the change ids by running `jj bookmark list BOOKMARK-NAME`.)
-- If you want to discard one of the two changes and just use the other one, say
-  `jj bookmark move BOOKMARK-NAME -r CHANGE-ID` for the change you want to keep.
-- If you want to rebase one of the changes to come _after_ the other, say
-  `jj rebase -b CHANGE-ID-2 -d CHANGE-ID-1`, then
-  `jj bookmark move BOOKMARK-NAME -r CHANGE-ID-2`.
-  This will rebase not only the second change itself, but all changes after it forked away from the
-  first change.
+- 2つの変更をマージしたい場合、`jj new CHANGE-ID-1 CHANGE-ID-2`と言い、ファイルコンフリクトを解決し、次に`jj bookmark move BOOKMARK-NAME`でブックマークを更新します。
+  （変更IDは`jj bookmark list BOOKMARK-NAME`を実行して取得できます。）
+- 2つの変更のうち1つを破棄し、もう1つだけを使用したい場合、保持したい変更に対して`jj bookmark move BOOKMARK-NAME -r CHANGE-ID`と言います。
+- 1つの変更を他の変更の後にリベースしたい場合、`jj rebase -b CHANGE-ID-2 -d CHANGE-ID-1`と言い、次に`jj bookmark move BOOKMARK-NAME -r CHANGE-ID-2`と言います。
+  これにより、2番目の変更自体だけでなく、最初の変更から分岐した後のすべての変更がリベースされます。
 
-== Commands
+== コマンド
 
-=== Global Setup Commands
+=== グローバル設定コマンド
 
 ```
 jj config set --user user.name  MY_NAME
 jj config set --user user.email MY_EMAIL
 jj config set --user ui.editor  MY_EDITOR
 
-jj config edit --user  // Manually edit config file
+jj config edit --user  // 設定ファイルを手動で編集
 ```
 
-Instead of `--user`, you can pass `--repo` to change the repository specific config, which takes
-priority.
+`--user`の代わりに`--repo`を渡して、リポジトリ固有の設定を変更することができます。これが優先されます。
 
-=== Repository Commands
+=== リポジトリコマンド
 
-- `jj git init`, or `jj git clone URL [DESTINATION]`. Make or clone a git-backed repo.
-- `jj git init --colocate`. Make an existing `git` repo also be a `jj` repo.
+- `jj git init`、または`jj git clone URL [DESTINATION]`。gitバックのリポジトリを作成またはクローンします。
+- `jj git init --colocate`。既存の`git`リポジトリを`jj`リポジトリとしても機能させます。
 
-=== Editing your Local Repo
+=== ローカルリポジトリの編集
 
-The attached JJ Cheat Sheet visually describes the most common/fundamental commands for editing a
-`jj` repo.
+添付のJJ Cheat Sheetは、`jj`リポジトリを編集するための最も一般的で基本的なコマンドを視覚的に説明しています。
 
-There are also a couple of "alias" commands that are best thought of as combinations of other `jj`
-commands:
+また、他の`jj`コマンドの組み合わせと考えるのが最適な「エイリアス」コマンドもいくつかあります：
 
-- `jj commit`. Shorthand for `jj describe; jj new`.
-- `jj bookmark set BOOKMARK`. Either `create` or `move` the bookmark, whichever is valid.
+- `jj commit`。`jj describe; jj new`の省略形。
+- `jj bookmark set BOOKMARK`。有効な場合、ブックマークを`create`または`move`します。
 
-// ## Commands
+// ## コマンド
 // 
-// - `jj abandon REVISION`: REVISION defaults to `@`. Delete the change (delete that node in the
-//   graph). It's children now point at its parent(s). This could introduce conflicts. If `@` is the
-//   same as `REVISION`, make `@` be a new empty change on top of the parent.
-// - `jj backout -r REVISION_r -d REVISION_d`: Create a new change (new node). Its parent is
-//   `REVISION_d`. Its modification is the opposite of the modification of `REVISION_r`. Its
-//   description is `Back out "THE DESCRIPTION OF REVISION_r"`.
-// - `jj bookmark create BOOKMARK -r REVISION`. REVISION defaults to `@`. Label REVISION with a
-//   bookmark named BOOKMARK. (Does propagate to remote.)
-// - `jj bookmark delete BOOKMARK`. Deletes the bookmark label named BOOKMARK. (Does propagate to
-//   remote.)
-// - `jj bookmark list`. Lists all bookmarks and the changes they point at.
-// - `jj bookmark rename BOOKMARK_OLD BOOKMARK_NEW`. Renames the bookmark. (QUESTION: Is this the same
-//   as delete and then create? How does it interact with pushing? If you rename&push, does it delete
-//   the old branch on the remote?) Is local only!
-// - `jj bookmark move BOOKMARK --to REVISION`. Move the bookmark label to point at REVISION instead.
-//   REVISION defaults to `@`.
-// - `jj describe`. Open an editor to set the description of the current change. Or say `jj describe -m
-//   "COMMIT MESSAGE"` to specify it on the command line.
-// - `jj show`. Print the description for `@`.
-// - `jj diff PATHS...`. Show the diff for the files at PATHS, between this revision (`@`) and its
-//   parent (`@-`). You can pass `--from REVISION` and `--to REVISION` to see the diff between
-//   arbitrary changes. TODO: compare to `jj interdiff`.
-// - `jj interdiff PATHS...`. TODO. Is this advanced?
-// - `jj edit REVISION`. Move `@` (the "working-copy revision") to point at REVISION.
-// - `jj file track/untrack`.
-// - `jj log PATHS...`. Prints the DAG, limited to those nodes that modified PATHS. QUESTION: when do
-//   you need to run `jj log -r ..`?
-// - `jj new`. Create a new empty commit on top of `@`, and edit it (move `@` to it). `-m "MESSAGE"`
-//   additionally sets its description. `jj new REVISIONS...` specifies the parents of the new commit;
-//   if there are multiple parents you're making a merge commit.
-// - `jj status` (alias: `jj st`). Print some basic info about the repo.
-// - `jj restore --from REVISION PATHS...`. Make the files for this commit match those at REVISION.
-// - `jj undo`. Undo the last thing you did.
-// - `jj squash`. Move all changes from this revision to its parent.
-// - `jj rebase`. TODO.
-// - `jj resolve!!`. TODO.
+// - `jj abandon REVISION`：REVISIONはデフォルトで`@`です。変更を削除します（グラフ内のノードを削除します）。その子は今やその親にポイントします。これによりコンフリクトが発生する可能性があります。`@`が`REVISION`と同じ場合、`@`を親の上に新しい空の変更にします。
+// - `jj backout -r REVISION_r -d REVISION_d`：新しい変更（新しいノード）を作成します。その親は`REVISION_d`です。その変更は`REVISION_r`の変更の反対です。その説明は`Back out "THE DESCRIPTION OF REVISION_r"`です。
+// - `jj bookmark create BOOKMARK -r REVISION`。REVISIONはデフォルトで`@`です。BOOKMARKという名前のブックマークでREVISIONをラベル付けします（リモートに伝播します）。
+// - `jj bookmark delete BOOKMARK`。BOOKMARKという名前のブックマークラベルを削除します（リモートに伝播します）。
+// - `jj bookmark list`。すべてのブックマークとそれらが指している変更をリストします。
+// - `jj bookmark rename BOOKMARK_OLD BOOKMARK_NEW`。ブックマークの名前を変更します（質問：これは削除してから作成するのと同じですか？プッシュとどのように相互作用しますか？名前を変更してプッシュすると、リモートで古いブランチが削除されますか？）これはローカルのみです！
+// - `jj bookmark move BOOKMARK --to REVISION`。ブックマークラベルをREVISIONに移動します。REVISIONはデフォルトで`@`です。
+// - `jj describe`。エディタを開い��現在の変更の説明を設定します。または、`jj describe -m "COMMIT MESSAGE"`と言ってコマンドラインで指定します。
+// - `jj show`。`@`の説明を印刷します。
+// - `jj diff PATHS...`。このリビジョン（`@`）とその親（`@-`）の間のPATHSのファイルの差分を表示します。`--from REVISION`および`--to REVISION`を渡して、任意の変更間の差分を表示できます。TODO：`jj interdiff`と比較します。
+// - `jj interdiff PATHS...`。TODO。これは高度ですか？
+// - `jj edit REVISION`。`@`（「作業コピーリビジョン」）をREVISIONに移動します。
+// - `jj file track/untrack`。
+// - `jj log PATHS...`。PATHSを変更したノードに限定してDAGを印刷します。質問：いつ`jj log -r ..`を実行する必要がありますか？
+// - `jj new`。`@`の上に新しい空のコミットを作成し、それを編集します（`@`をそれに移動します）。`-m "MESSAGE"`はさらにその説明を設定します。`jj new REVISIONS...`は新しいコミットの親を指定します。複数の親がいる場合、マージコミットを作成しています。
+// - `jj status`（エイリアス：`jj st`）。リポジトリに関する基本情報を印刷します。
+// - `jj restore --from REVISION PATHS...`。このコミットのファイルをREVISIONのものと一致させます。
+// - `jj undo`。最後に行ったことを元に戻します。
+// - `jj squash`。このリビジョンからその親へのすべての変更を移動します。
+// - `jj rebase`。TODO。
+// - `jj resolve!!`。TODO。
 // 
-// ## Advanced Commands
+// ## 高度なコマンド
 // 
-// - `jj bookmark forget BOOKMARK`. Deletes the bookmark label named BOOKMARK, but "forgets" that it
-//   exists remotely. It will be recreated if you pull again!
-// - `jj bookmark track BOOKMARK@REMOTE`. TODO
-// - `jj bookmark untrack BOOKMARK@REMOTE`. TODO
-// - `jj duplicate`. TODO
-// - `jj new --insert-before REVISION` and `jj new --insert-after REVISION`. TODO.
-// - `jj prev` and `jj next`?
-// - `jj simplify-parents`. Simplifies the DAG in a lossless way. (A -> B, A -> C, B ->+ C becomes A ->
-//   B, B ->+ C).
-// - `jj workspace`. TODO.
-// - `jj undo OPERATION`. TODO.
-// - `jj split`. Split a commit in two, with an editor.
-// - `jj parallelize`. TODO.
+// - `jj bookmark forget BOOKMARK`。BOOKMARKという名前のブックマークラベルを削除しますが、それがリモートに存在することを「忘れます」。再度プルすると再作成されます！
+// - `jj bookmark track BOOKMARK@REMOTE`。TODO
+// - `jj bookmark untrack BOOKMARK@REMOTE`。TODO
+// - `jj duplicate`。TODO
+// - `jj new --insert-before REVISION`および`jj new --insert-after REVISION`。TODO。
+// - `jj prev`および`jj next`？
+// - `jj simplify-parents`。DAGを無損失で簡略化します（A -> B、A -> C、B ->+ CはA -> B、B ->+ Cになります）。
+// - `jj workspace`。TODO。
+// - `jj undo OPERATION`。TODO。
+// - `jj split`。コミットを2つに分割し、エディタで編集します。
+// - `jj parallelize`。TODO。


### PR DESCRIPTION
Translate the content of `reference.typ` and `cheat-sheet.typ` from English to Japanese.

* **reference.typ**
  - Translate headings, descriptions, and command examples to Japanese.
  - Update all text to reflect the Japanese translation accurately.

* **cheat-sheet.typ**
  - Translate command descriptions and labels to Japanese.
  - Update the cheat sheet title and attribution to Japanese.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dai/jj-notes/pull/1?shareId=963d14cb-0bff-4bfa-855b-166aa08d02f1).